### PR TITLE
Split into multiple modules

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -1,0 +1,131 @@
+use clap::{Args, Subcommand};
+use strum::Display;
+// use std::fmt;
+
+mod area;
+pub use area::*;
+mod distance;
+pub use distance::*;
+
+#[derive(Debug, Args)]
+pub struct Conversions {
+    #[command(subcommand)]
+    convert_type: ConversionOption,
+}
+
+#[derive(Subcommand, Debug)]
+enum ConversionOption {
+    /// Area Conversions
+    Area(area::AreaConversion),
+    /// Distance Conversions
+    Distance(distance::DistanceConversion),
+}
+
+#[repr(C)]
+union UnitUnion {
+    area: area::AreaUnits,
+    distance: distance::DistanceUnits,
+}
+
+#[derive(Debug, Display)]
+enum ConverstionType {
+    Area,
+    Distance,
+}
+
+fn unit_conversions(
+    from: &UnitUnion,
+    to: &UnitUnion,
+    val: &f64,
+    conversion_type: &ConverstionType,
+) -> f64 {
+    unsafe {
+        match conversion_type {
+            ConverstionType::Area => area::area_conversions(&from.area, &to.area, val),
+            ConverstionType::Distance => {
+                distance::distance_conversions(&from.distance, &to.distance, val)
+            }
+        }
+    }
+}
+
+fn format_conversion_output(
+    from_unit: &UnitUnion,
+    to_unit: &UnitUnion,
+    from_val: &f64,
+    to_val: &f64,
+    conversion_type: &ConverstionType,
+) -> String {
+    unsafe {
+        match conversion_type {
+            ConverstionType::Distance => format!(
+                "{from_val} {:?} = {to_val} {:?}",
+                from_unit.distance, to_unit.distance
+            ),
+            ConverstionType::Area => {
+                format!(
+                    "{from_val} {:?} = {to_val} {:?}",
+                    from_unit.area, to_unit.area
+                )
+            }
+        }
+    }
+}
+
+fn conversion_prep(
+    from: &UnitUnion,
+    to: &Vec<UnitUnion>,
+    val: &f64,
+    conversion_type: &ConverstionType,
+) {
+    for unit in to {
+        let conversion = unit_conversions(from, unit, val, conversion_type);
+        let output = format_conversion_output(from, unit, val, &conversion, conversion_type);
+        println!("{output}");
+    }
+}
+
+pub fn perform_conversion(conversion_args: &Conversions, _verbose: bool) {
+    match &conversion_args.convert_type {
+        ConversionOption::Area(conversion_option) => {
+            conversion_prep(
+                &UnitUnion {
+                    area: conversion_option.from,
+                },
+                &conversion_option
+                    .to
+                    .iter()
+                    .map(|unit| UnitUnion { area: *unit })
+                    .collect::<Vec<UnitUnion>>(),
+                &conversion_option.value,
+                &ConverstionType::Area,
+            );
+        }
+        ConversionOption::Distance(conversion_option) => {
+            conversion_prep(
+                &UnitUnion {
+                    distance: conversion_option.from,
+                },
+                &conversion_option
+                    .to
+                    .iter()
+                    .map(|unit| UnitUnion { distance: *unit })
+                    .collect::<Vec<UnitUnion>>(),
+                &conversion_option.value,
+                &ConverstionType::Distance,
+            );
+        }
+    }
+}
+
+// impl fmt::Debug for UnitUnion {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         unsafe {
+//             write!(
+//                 f,
+//                 "UnitUnion elements Are: {}, and {}",
+//                 &self.area, &self.distance
+//             )
+//         }
+//     }
+// }

--- a/src/conversions/area.rs
+++ b/src/conversions/area.rs
@@ -1,5 +1,14 @@
-use clap::{Subcommand, ValueEnum};
+use clap::{Args, Subcommand, ValueEnum};
 use strum::Display;
+
+#[derive(Debug, Args)]
+pub struct AreaConversion {
+    #[arg(long, required = true)]
+    pub from: AreaUnits,
+    pub value: f64,
+    #[arg(long, required = true)]
+    pub to: Vec<AreaUnits>,
+}
 
 #[derive(Subcommand, Debug, Display, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum AreaUnits {

--- a/src/conversions/distance.rs
+++ b/src/conversions/distance.rs
@@ -1,5 +1,15 @@
-use clap::{Subcommand, ValueEnum};
+use clap::{Args, Subcommand, ValueEnum};
 use strum::Display;
+
+#[derive(Debug, Args)]
+pub struct DistanceConversion {
+    #[clap(long, required = true, display_order = 1)]
+    pub from: DistanceUnits,
+    #[clap(display_order = 2)]
+    pub value: f64,
+    #[clap(long, required = true, display_order = 3)]
+    pub to: Vec<DistanceUnits>,
+}
 
 #[derive(Subcommand, Debug, Display, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum DistanceUnits {

--- a/src/dateinfo.rs
+++ b/src/dateinfo.rs
@@ -4,7 +4,7 @@ use strum::Display;
 use time::{format_description, Date, Duration, OffsetDateTime};
 
 #[derive(Subcommand, Debug, Display, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-pub enum DateDuration {
+enum DateDuration {
     #[clap(action=clap::ArgAction::SetTrue)]
     Weeks,
     #[clap(action=clap::ArgAction::SetTrue)]
@@ -16,12 +16,12 @@ pub enum DateDuration {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct DateTimeKeeper {
-    pub initial_utc: OffsetDateTime,
+struct DateTimeKeeper {
+    initial_utc: OffsetDateTime,
 }
 
 #[derive(Debug, Args, Clone)]
-pub struct Diff {
+struct Diff {
     #[clap(help = "Date to perform diff operations on")]
     date1: String,
 
@@ -157,7 +157,7 @@ fn set_initial_date_argument(input_date: Option<&str>, verbose: bool) -> DateTim
     }
 }
 
-pub fn do_diff_date(diff_args: &Diff, verbose: bool) {
+fn do_diff_date(diff_args: &Diff, verbose: bool) {
     let first_date = set_initial_date_argument(Some(&diff_args.date1), verbose);
     let second_date = set_initial_date_argument(diff_args.date2.as_deref(), verbose);
     if verbose {
@@ -177,5 +177,29 @@ pub fn do_diff_date(diff_args: &Diff, verbose: bool) {
         };
 
         println!("{output}");
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct DateOperations {
+    #[command(subcommand)]
+    operation_type: DateOption,
+}
+
+#[derive(Subcommand, Debug)]
+enum DateOption {
+    ///Add two dates or time periods together
+    // Add(conversions::AreaConversion),
+    ///Diff Two Dates
+    Diff(Diff),
+}
+
+pub fn handle_date_operations(date_args: &DateOperations, verbose: bool) {
+    match &date_args.operation_type {
+        DateOption::Diff(diff_args) => {
+            do_diff_date(diff_args, verbose);
+        } // DateOption::Add(add_args) => {
+          //     println!("{:?}", add_args)
+          // }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-use clap::{Args, Parser, Subcommand};
-use std::fmt;
+use clap::{Parser, Subcommand};
 use strum::Display;
-mod area;
+mod conversions;
+// use area::*;
+// use conversions::area::*;
+// use conversions::distance::*;
 mod dateinfo;
-mod distance;
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -22,183 +23,21 @@ struct Cli {
 #[derive(Subcommand, Display, Debug)]
 enum Commands {
     /// Unit conversions
-    Conversion(Conversions),
+    Convert(conversions::Conversions),
     /// Date Operations
-    Dates(DateOperations),
-}
-
-#[derive(Args, Debug)]
-struct DateOperations {
-    #[command(subcommand)]
-    operation_type: DateOption,
-}
-
-#[derive(Debug, Args)]
-struct Conversions {
-    #[command(subcommand)]
-    convert_type: ConversionOption,
-}
-
-#[derive(Debug, Display)]
-enum ConverstionType {
-    Area,
-    Distance,
-}
-
-#[derive(Subcommand, Debug)]
-enum DateOption {
-    ///Add two dates or time periods together
-    Add(AreaConversion),
-    ///Diff Two Dates
-    Diff(dateinfo::Diff),
-}
-
-#[derive(Subcommand, Debug)]
-enum ConversionOption {
-    /// Area Conversions
-    Area(AreaConversion),
-    /// Distance Conversions
-    Distance(DistanceConversion),
-}
-
-#[derive(Debug, Args)]
-struct AreaConversion {
-    #[arg(long, required = true)]
-    from: area::AreaUnits,
-    value: f64,
-    #[arg(long, required = true)]
-    to: Vec<area::AreaUnits>,
-}
-
-#[derive(Debug, Args)]
-struct DistanceConversion {
-    #[clap(long, required = true, display_order = 1)]
-    from: distance::DistanceUnits,
-    #[clap(display_order = 2)]
-    value: f64,
-    #[clap(long, required = true, display_order = 3)]
-    to: Vec<distance::DistanceUnits>,
-}
-
-#[repr(C)]
-union UnitUnion {
-    area: area::AreaUnits,
-    distance: distance::DistanceUnits,
-}
-
-impl fmt::Debug for UnitUnion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unsafe {
-            write!(
-                f,
-                "UnitUnion elements Are: {}, and {}",
-                &self.area, &self.distance
-            )
-        }
-    }
-}
-
-fn unit_conversions(
-    from: &UnitUnion,
-    to: &UnitUnion,
-    val: &f64,
-    conversion_type: &ConverstionType,
-) -> f64 {
-    unsafe {
-        match conversion_type {
-            ConverstionType::Area => area::area_conversions(&from.area, &to.area, val),
-            ConverstionType::Distance => {
-                distance::distance_conversions(&from.distance, &to.distance, val)
-            }
-        }
-    }
-}
-
-fn format_output(
-    from_unit: &UnitUnion,
-    to_unit: &UnitUnion,
-    from_val: &f64,
-    to_val: &f64,
-    conversion_type: &ConverstionType,
-) -> String {
-    unsafe {
-        match conversion_type {
-            ConverstionType::Distance => format!(
-                "{from_val} {:?} = {to_val} {:?}",
-                from_unit.distance, to_unit.distance
-            ),
-            ConverstionType::Area => {
-                format!(
-                    "{from_val} {:?} = {to_val} {:?}",
-                    from_unit.area, to_unit.area
-                )
-            }
-        }
-    }
-}
-
-fn conversion_prep(
-    from: &UnitUnion,
-    to: &Vec<UnitUnion>,
-    val: &f64,
-    conversion_type: &ConverstionType,
-) {
-    for unit in to {
-        let conversion = unit_conversions(from, unit, val, conversion_type);
-        let output = format_output(from, unit, val, &conversion, conversion_type);
-        println!("{output}");
-    }
+    Dates(dateinfo::DateOperations),
 }
 
 fn main() {
     let cli = Cli::parse();
     let verbose = cli.verbose;
+    if verbose {
+        println!("CLI Args: {:?}", cli);
+    }
     match &cli.command {
-        Commands::Conversion(args) => {
-            if verbose {
-                println!("CLI Args: {:?}", cli);
-            }
-            match &args.convert_type {
-                ConversionOption::Area(conversion_option) => {
-                    conversion_prep(
-                        &UnitUnion {
-                            area: conversion_option.from,
-                        },
-                        &conversion_option
-                            .to
-                            .iter()
-                            .map(|unit| UnitUnion { area: *unit })
-                            .collect::<Vec<UnitUnion>>(),
-                        &conversion_option.value,
-                        &ConverstionType::Area,
-                    );
-                }
-                ConversionOption::Distance(conversion_option) => {
-                    conversion_prep(
-                        &UnitUnion {
-                            distance: conversion_option.from,
-                        },
-                        &conversion_option
-                            .to
-                            .iter()
-                            .map(|unit| UnitUnion { distance: *unit })
-                            .collect::<Vec<UnitUnion>>(),
-                        &conversion_option.value,
-                        &ConverstionType::Distance,
-                    );
-                }
-            }
-        }
-        Commands::Dates(args) => match &args.operation_type {
-            DateOption::Diff(diff_args) => {
-                println!("{:?}", diff_args);
-                dateinfo::do_diff_date(diff_args, verbose);
-            }
-            DateOption::Add(add_args) => {
-                println!("{:?}", add_args)
-            }
-        },
-        _ => todo!("Not done "),
+        Commands::Convert(args) => conversions::perform_conversion(args, verbose),
+
+        Commands::Dates(args) => dateinfo::handle_date_operations(args, verbose),
     }
 }
 


### PR DESCRIPTION
This splits the code into various modules for
a cleaner interface and code readability.

There is now an interface for date operations
and conversions which abstracts the conversion
type being performed.